### PR TITLE
Use dependencies rather than devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "authors": [
         "R. Moorman <rob@moori.nl>"
     ],
-    "devDependencies": {
+    "dependencies": {
         "backbone": "~1.1.2",
         "jquery": "~2.1.1",
         "underscore": "~1.7.0"


### PR DESCRIPTION
Listed dependencies are required in production and should therefor be listed on the dependencies property (not devDependencies)
http://bower.io/docs/creating-packages/#bowerjson
