### PR TITLE
Missing 'main' property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
         "test"
     ],
     "license": "MIT",
+    "main": "backbone.inheritance.js",
     "name": "backbone-inheritance",
     "version": "0.1.0"
 }


### PR DESCRIPTION
When installing this package with bower, you get the following error:
bower backbone-inheritance#0.1.0     invalid-meta backbone-inheritance is missing "main" entry in bower.json

See http://bower.io/docs/creating-packages/
