### PR TITLE
Added version range in bower to use Backbone 1.2.3 as well

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
         "R. Moorman <rob@moori.nl>"
     ],
     "dependencies": {
-        "backbone": "~1.1.2",
+        "backbone": "1.1.2 - 1.2.3",
         "jquery": "~2.1.1",
         "underscore": "~1.7.0"
     },


### PR DESCRIPTION
Current version cannot install if your project uses Backbone 1.2.3 becaused the version is pinned down to 1.1.2